### PR TITLE
[BUG FIX] Add an lightning bonus guide index entry for "rebalance-lnd"

### DIFF
--- a/bonus/lightning/index.md
+++ b/bonus/lightning/index.md
@@ -40,6 +40,7 @@ has_toc: false
 
 ## Liquidity management (rebalancing)
 * **[Balance of Satoshis](balance-of-satoshis.md)** - a tool to rebalance your channels and set up a LN node monitoring Telegram bot
+* **[rebalance-lnd](rebalance-lnd.md)** - a simple script to manage your channel liquidity by doing circular rebalancing
 
 ---
 


### PR DESCRIPTION
#### What

The bonus guide for `rebalance-lnd` has just been merged into the guide. However, there is no entry for it in the lightning bonus guide index page.

This PR adds an entry for rebalance-lnd in the index.

### Why

The bonus guide cannot be accessed using the guide at the moment.

#### How

* Added an entry for `rebalance-lnd` to `bonus/lightning/index.md`
* The entry is undet the sub-heading "Liquidity management (rebalancing)", together with `Balance of Satoshis`

#### Scope

- [ ] significant change to core configuration
- [ ] independent bonus guide
- [x] simple bug fix

#### Test & maintenance

Check that the entry appears in the index and that the links point to the bonus guide 
